### PR TITLE
Make cropper RGB friendly, N-dimensional, and sliceable from any orthogonal viewpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-env/
 build/
 develop-eggs/
 dist/
@@ -20,10 +19,12 @@ lib64/
 parts/
 sdist/
 var/
+wheels/
+share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
-venv/
+MANIFEST
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -38,16 +39,17 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.nox/
 .coverage
 .coverage.*
 .cache
 nosetests.xml
 coverage.xml
-*,cover
+*.cover
+*.py,cover
 .hypothesis/
-.napari_cache
-.idea/
-.napari
+.pytest_cache/
+cover/
 
 # Translations
 *.mo
@@ -56,29 +58,95 @@ coverage.xml
 # Django stuff:
 *.log
 local_settings.py
+db.sqlite3
+db.sqlite3-journal
 
-# Flask instance folder
+# Flask stuff:
 instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
 
 # Sphinx documentation
 docs/_build/
 
-# MkDocs documentation
-/site/
-
 # PyBuilder
+.pybuilder/
 target/
 
-# IPython Notebook
+# Jupyter Notebook
 .ipynb_checkpoints
 
+# IPython
+profile_default/
+ipython_config.py
+
 # pyenv
-.python-version
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
 
-# OS
-.DS_Store
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
 
-# written by setuptools_scm
-*/_version.py
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
 
-Untitled.ipynb
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintainted in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 
-Copyright (c) 2021, Robert Haase
+Copyright (c) 2021, Robert Haase, Tim Morello
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/napari_crop/_function.py
+++ b/napari_crop/_function.py
@@ -18,7 +18,7 @@ def crop_region(
     layer: napari.layers.Layer,
     shapes_layer: napari.layers.Shapes,
     viewer: napari.Viewer,
-):
+) -> napari.layers.Layer:
     if shapes_layer is None:
         shapes_layer = viewer.add_shapes([])
         shapes_layer.mode = "add_rectangle"

--- a/napari_crop/_function.py
+++ b/napari_crop/_function.py
@@ -17,10 +17,8 @@ def napari_experimental_provide_function():
 def crop_region(
     layer: napari.layers.Layer,
     shapes_layer: napari.layers.Shapes,
-    viewer: napari.Viewer,
 ) -> napari.layers.Layer:
     if shapes_layer is None:
-        shapes_layer = viewer.add_shapes([])
         shapes_layer.mode = "add_rectangle"
         warnings.warn("Please annotate a region to crop.")
         return
@@ -59,6 +57,6 @@ def crop_region(
 
     layer_props["name"] = layer_props["name"] + " (cropped)"
     if layer_type == "image":
-        return viewer.add_image(cropped_data, **layer_props)
+        return napari.layers.Image(cropped_data, **layer_props)
     if layer_type == "labels":
-        return viewer.add_labels(cropped_data, **layer_props)
+        return napari.layers.Labels(cropped_data, **layer_props)

--- a/napari_crop/_function.py
+++ b/napari_crop/_function.py
@@ -56,17 +56,6 @@ def crop_region(
         )
         cropped_data = layer_data[slices]
 
-        # TODO get this part working for RGB and from orthogonal views
-        if shape_type != "rectangle":
-            # set pixels outside shape to zero
-            mask2D = (
-                napari.layers.Shapes(shape - start, shape_type=shape_type)
-                .to_masks()
-                .squeeze()
-            )
-
-            mask = np.broadcast_to(mask2D, cropped_data.shape)
-            cropped_data[~mask] = 0
 
     layer_props["name"] = layer_props["name"] + " (cropped)"
     if layer_type == "image":

--- a/napari_crop/_function.py
+++ b/napari_crop/_function.py
@@ -24,7 +24,7 @@ def crop_region(layer: napari.layers.Layer, shapes_layer: napari.layers.Shapes, 
         warnings.warn("Please select an image or labels layer to crop.")
         return
 
-    data = layer.data
+    data, layer_props, layer_type = layer.as_layer_data_tuple()
 
     rectangle = viewer.layers[1].data[-1]
     start_position = rectangle.min(axis=0)
@@ -55,20 +55,8 @@ def crop_region(layer: napari.layers.Layer, shapes_layer: napari.layers.Shapes, 
         warnings.warn("Data with " + str(len(data.shape)) + " dimensions not supported for cropping.")
         return
 
-    if isinstance(layer, napari.layers.Image):
-        new_layer = viewer.add_image(cropped_data,
-            name = layer.name + "(cropped)",
-            opacity = layer.opacity,
-            gamma = layer.gamma,
-            contrast_limits = layer.contrast_limits,
-            colormap = layer.colormap,
-            blending = layer.blending,
-            interpolation = layer.interpolation,
-        )
-    else : # labels
-        new_layer = viewer.add_labels(
-            np.asarray(cropped_data),
-            opacity=layer.opacity,
-            blending=layer.blending,
-        )
-        new_layer.contour = layer.contour
+    layer_props["name"] = layer_props["name"] + " (cropped)"
+    if layer_type == "image":
+        viewer.add_image(cropped_data, **layer_props)
+    if layer_type == "labels":
+        viewer.add_labels(cropped_data, **layer_props)

--- a/napari_crop/_function.py
+++ b/napari_crop/_function.py
@@ -12,15 +12,23 @@ import napari
 def napari_experimental_provide_function():
     return [crop_region]
 
+
 @register_function(menu="Utilities > Crop region")
-def crop_region(layer: napari.layers.Layer, shapes_layer: napari.layers.Shapes, viewer : napari.Viewer):
+def crop_region(
+    layer: napari.layers.Layer,
+    shapes_layer: napari.layers.Shapes,
+    viewer: napari.Viewer,
+):
     if shapes_layer is None:
         shapes_layer = viewer.add_shapes([])
-        shapes_layer.mode = 'add_rectangle'
+        shapes_layer.mode = "add_rectangle"
         warnings.warn("Please annotate a region to crop.")
         return
 
-    if not(isinstance(layer, napari.layers.Image) or isinstance(layer, napari.layers.Labels)):
+    if not (
+        isinstance(layer, napari.layers.Image)
+        or isinstance(layer, napari.layers.Labels)
+    ):
         warnings.warn("Please select an image or labels layer to crop.")
         return
 

--- a/napari_crop/_function.py
+++ b/napari_crop/_function.py
@@ -51,6 +51,6 @@ def crop_region(layer: napari.layers.Layer, shapes_layer: napari.layers.Shapes, 
 
     layer_props["name"] = layer_props["name"] + " (cropped)"
     if layer_type == "image":
-        viewer.add_image(cropped_data, **layer_props)
+        return viewer.add_image(cropped_data, **layer_props)
     if layer_type == "labels":
-        viewer.add_labels(cropped_data, **layer_props)
+        return viewer.add_labels(cropped_data, **layer_props)

--- a/napari_crop/_function.py
+++ b/napari_crop/_function.py
@@ -18,6 +18,7 @@ def crop_region(
     layer: napari.layers.Layer,
     shapes_layer: napari.layers.Shapes,
 ) -> napari.layers.Layer:
+
     if shapes_layer is None:
         shapes_layer.mode = "add_rectangle"
         warnings.warn("Please annotate a region to crop.")
@@ -54,6 +55,18 @@ def crop_region(
             for first, last in np.stack([start, stop]).astype(int).T
         )
         cropped_data = layer_data[slices]
+
+        # TODO get this part working for RGB and from orthogonal views
+        if shape_type != "rectangle":
+            # set pixels outside shape to zero
+            mask2D = (
+                napari.layers.Shapes(shape - start, shape_type=shape_type)
+                .to_masks()
+                .squeeze()
+            )
+
+            mask = np.broadcast_to(mask2D, cropped_data.shape)
+            cropped_data[~mask] = 0
 
     layer_props["name"] = layer_props["name"] + " (cropped)"
     if layer_type == "image":

--- a/napari_crop/_tests/test_function.py
+++ b/napari_crop/_tests/test_function.py
@@ -12,12 +12,10 @@ arr_2d = np.arange(0, 25).reshape((5, 5))  # 2d case
 #        [20, 21, 22, 23, 24]])
 shapes = [
     np.array([[1, 1], [1, 3], [4, 3], [4, 1]]),
-    np.array([[0, 2], [4, 4], [4, 2], [2, 0]]),
 ]
-shape_types = ["rectangle", "polygon"]
+shape_types = ["rectangle"]
 crop_expected = [
     np.array([[6, 7, 8], [11, 12, 13], [16, 17, 18], [21, 22, 23]]),
-    np.array([[0, 0, 2, 0, 0],[0, 6, 7, 0, 0],[0, 11, 12, 13, 0],[0, 0, 17, 18, 0],[0, 0, 0, 0, 0]]),  # fmt: skip
 ]
 
 # rectangle crop
@@ -60,11 +58,10 @@ shape_data = [
     np.array([[2, 2], [2, 5], [4, 5], [4, 2]]),  # 2x3 crop
     np.array([[-2, -2], [-2, 5], [4, 5], [4, -2]]),  # neg crop
     np.array([[-100, -100], [-100, 100], [100, 100], [100, -100]]),  # oversided crop
-    np.array([[0, 2], [4, 4], [4, 2], [2, 0]]),  # diamond crop
 ]
-shape_types = ["rectangle", "rectangle", "rectangle", "polygon"]
 image_data_ids = ["2D_rgb", "2D_rgba", "2D", "3D", "6D"]
-shape_data_ids = ["2x3_crop", "neg_crop", "big_crop", "poly_crop"]
+shape_types = ["rectangle", "rectangle", "rectangle"]
+shape_data_ids = ["2x3_crop", "neg_crop", "big_crop"]
 
 
 @pytest.mark.parametrize("image_data,rgb", image_data, ids=image_data_ids)
@@ -86,38 +83,3 @@ def test_crop_function_nd(image_data, rgb, shape_data, shape_type, make_napari_v
     nlayers = len(viewer.layers)
     viewer.add_layer(crop_region(img_layer, shp_layer))
     assert len(viewer.layers) == nlayers + 1
-
-    # last two dimenions of output should match size of shape
-
-    # check that cropped is expected dimensions, assume the values are correct
-
-    # example with 6 dimensions:
-    # rectangle in XY plane at on z axis of first channel at time point zero of first scene
-    #    S  T  C  Z  Y  X
-    # [ [0, 0, 0, 0, 0, 0],
-    #   [0, 0, 0, 0, 0, 2],
-    #   [0, 0, 0, 0, 4, 2],
-    #   [0, 0, 0, 0, 4, 0] ]
-
-    # min and max values along each dimenions are
-    #   S  T  C  Z  Y  X
-    #  [0, 0, 0, 0, 0, 0] <- min = 'start'
-    #  [0, 0, 0, 0, 4, 2] <- max = 'stop'
-
-    # stacking these arrays gives
-    #    S  T  C  Z  Y  X
-    # [ [0, 0, 0, 0, 0, 0],  <- min
-    #   [0, 0, 0, 0, 4, 2] ] <- max
-
-    # transposing gives
-    #   min  max
-    # [ [0,  0],  <- S
-    #   [0,  0],  <- T
-    #   [0,  0],  <- C
-    #   [0,  0],  <- Z
-    #   [0,  4],  <- Y
-    #   [0,  2] ] <- X
-
-    # each pair represents a slice along the respective dimension
-    # slice stop is non-inclusive, so add 1
-    # (e.g. starts and stops at T=0, but `slice(0, 0)` would return nothing)

--- a/napari_crop/_tests/test_function.py
+++ b/napari_crop/_tests/test_function.py
@@ -1,0 +1,72 @@
+from napari_crop._function import crop_region
+import pytest
+import numpy as np
+
+
+arr_2d = np.arange(0, 25).reshape((5, 5))  # 2d case
+# array([[ 0,  1,  2,  3,  4],
+#        [ 5,  6,  7,  8,  9],
+#        [10, 11, 12, 13, 14],
+#        [15, 16, 17, 18, 19],
+#        [20, 21, 22, 23, 24]])
+shapes = [np.array([[1, 1], [1, 3], [4, 3], [4, 1]])]
+shape_types = [
+    "rectangle",
+]
+crop_expected = [np.array([[6, 7, 8], [11, 12, 13], [16, 17, 18], [21, 22, 23]])]
+# rectangle crop
+# array([[ 6,  7,  8],
+#        [11, 12, 13],
+#        [16, 17, 18],
+#        [21, 22, 23]])
+
+
+@pytest.mark.parametrize(
+    "shape,shape_type,crop_expected",
+    zip(shapes, shape_types, crop_expected),
+    ids=shape_types,
+)
+def test_crop_function_values_2d(make_napari_viewer, shape, shape_type, crop_expected):
+    """Test that the cropped output is the expected array."""
+
+    viewer = make_napari_viewer()
+    img_layer = viewer.add_image(arr_2d)
+    shapes_layer = viewer.add_shapes(shape, shape_type=shape_type)
+    cropped_actual = crop_region(img_layer, shapes_layer, viewer)
+    assert np.array_equal(crop_expected, cropped_actual.data)
+
+
+image_data = [
+    [np.random.random((8, 8, 3)), True],  # 2d rgb
+    [np.random.random((8, 8, 4)), True],  # 2d rgba
+    [np.random.random((8, 8)), False],  # 2d
+    [np.random.random((2, 8, 8)), False],  # 3d
+    [np.random.random((2, 2, 2, 2, 8, 8)), False],  # 6d
+]
+shape_data = [
+    np.array([[2, 2], [2, 5], [4, 5], [4, 2]]),  # 2x3 crop
+    np.array([[-2, -2], [-2, 5], [4, 5], [4, -2]]),  # neg crop
+    np.array([[-100, -100], [-100, 100], [100, 100], [100, -100]]),  # oversided crop
+]
+shape_types = ["rectangle", "rectangle", "rectangle"]
+image_data_ids = ["2D_rgb", "2D_rgba", "2D", "3D", "6D"]
+shape_data_ids = ["2x3_crop", "neg_crop", "big_crop"]
+
+
+@pytest.mark.parametrize("image_data,rgb", image_data, ids=image_data_ids)
+@pytest.mark.parametrize(
+    "shape_data,shape_type", zip(shape_data, shape_types), ids=shape_data_ids
+)
+def test_crop_function_nd(image_data, rgb, shape_data, shape_type, make_napari_viewer):
+    viewer = make_napari_viewer()
+
+    img_layer = viewer.add_image(image_data, rgb=rgb)
+
+    # shape data is (N,D) array where N is num verts and D is num dims
+    diff_dims = image_data.ndim - shape_data.shape[1]
+    shape_data = np.insert(shape_data, [-1], np.zeros(diff_dims), axis=1)
+    shp_layer = viewer.add_shapes(shape_data, shape_type=shape_type)
+
+    nlayers = len(viewer.layers)
+    crop_region(img_layer, shp_layer, viewer)
+    assert len(viewer.layers) == nlayers + 1

--- a/napari_crop/_tests/test_function.py
+++ b/napari_crop/_tests/test_function.py
@@ -12,10 +12,12 @@ arr_2d = np.arange(0, 25).reshape((5, 5))  # 2d case
 #        [20, 21, 22, 23, 24]])
 shapes = [
     np.array([[1, 1], [1, 3], [4, 3], [4, 1]]),
+    np.array([[0, 2], [4, 4], [4, 2], [2, 0]]),
 ]
-shape_types = ["rectangle"]
+shape_types = ["rectangle", "polygon"]
 crop_expected = [
     np.array([[6, 7, 8], [11, 12, 13], [16, 17, 18], [21, 22, 23]]),
+    np.array([[0, 0, 2, 0, 0],[0, 6, 7, 0, 0],[0, 11, 12, 13, 0],[0, 0, 17, 18, 0],[0, 0, 0, 0, 0]]),  # fmt: skip
 ]
 
 # rectangle crop
@@ -58,6 +60,7 @@ shape_data = [
     np.array([[2, 2], [2, 5], [4, 5], [4, 2]]),  # 2x3 crop
     np.array([[-2, -2], [-2, 5], [4, 5], [4, -2]]),  # neg crop
     np.array([[-100, -100], [-100, 100], [100, 100], [100, -100]]),  # oversided crop
+    np.array([[0, 2], [4, 4], [4, 2], [2, 0]]),  # diamond crop
 ]
 shape_types = ["rectangle", "rectangle", "rectangle", "polygon"]
 image_data_ids = ["2D_rgb", "2D_rgba", "2D", "3D", "4D"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = napari-crop
 version = 0.1.3
-author = Robert Haase
+author = Robert Haase, Tim Morello
 author_email = robert.haase@tu-dresden.de
 license = BSD-3-Clause
 url = https://github.com/haesleinhuepf/napari-crop


### PR DESCRIPTION
Hi Robert,

First of all, consider me a big fan of your napari plugins -- I really appreciate the number of tools you are creating and publishing for napari users!

Second, I was testing out this plugin and found it wasn't working on RGB images, so I dug into the code a little bit and thought of some ways to (hopefully) make it applicable to more scenarios. If you get some time to test it out, I'd really appreciate it!

I think the key features are:
1) it works with _any_ number of dimensions
2) you can draw a cropping region in an orthogonal view (e.g. XZ plane) and it'll give you the expected results
3) the slice indices aren't hard-coded, so it should be a little easier to maintain and adapt

I also wrote some tests to help my dev'ing (and hope they will be useful to the repo as well).

Finally, I see @zoccoler 's PR and am planning on trying to fit my changes in with his (polygon cropping). The code I'm sharing can be easily modified to output more than 1 new layer when multiple shapes are draw. 

Let me know what you think.

Best,
Tim